### PR TITLE
Change the redirect to 307 status code 

### DIFF
--- a/main.go
+++ b/main.go
@@ -77,7 +77,7 @@ func main() {
 			return c.String(http.StatusNotFound, err.Error())
 		}
 		//return c.Redirect(http.StatusPermanentRedirect, fmt.Sprint("https://", c.Request().Host, ".", c.Request().URL.Path))
-		return c.Redirect(http.StatusPermanentRedirect, fmt.Sprint(value, c.Request().URL.Path))
+		return c.Redirect(http.StatusTemporaryRedirect, fmt.Sprint(value, c.Request().URL.Path))
 	})
 
 	if config.CertPresent {


### PR DESCRIPTION
@auyer, I think the permanent redirect status code can be dangerous to the clients because they may understand they must use the new address in the future requests. When I red about the difference between the redirection codes (301, 302, 307, 308), this issue was confirmed:

> A browser redirects to this page and search engines update their links to the resource [1]

[1]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/307

More readings:
* https://stackoverflow.com/questions/42136829/whats-difference-between-http-301-and-308-status-codes
* https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/302
* https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/307
* https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/308
